### PR TITLE
e2e+build: Remove all refs to EOPA_LICENSE_* env vars.

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -257,7 +257,6 @@ jobs:
         env:
           BINARY: ${{ steps.enterprise-opa.outputs.binary }}
           EOPA_VERSION: ${{ steps.eopa-version.outputs.version }}
-          EOPA_LICENSE_TOKEN: ${{ secrets.STYRA_LOAD_LICENSE_TOKEN }}
           # credentials for data.git plugin
           GIT_GITHUB_TOKEN: ${{ secrets.E2E_GIT_GITHUB_TOKEN }}
           GIT_AZURE_TOKEN: ${{ secrets.E2E_GIT_AZURE_TOKEN }}
@@ -486,7 +485,6 @@ jobs:
       - run: make test
         working-directory: e2e/cli
         env:
-          EOPA_LICENSE_TOKEN: ${{ secrets.STYRA_LOAD_LICENSE_TOKEN }}
           IMAGE: ${{ steps.enterprise-opa.outputs.image }}
 
   performance-related:

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ build-debug: base-image-debug
 
 # build and run local ko-build container (no tags)
 run: build-local
-	docker run -e EOPA_LICENSE_TOKEN -e EOPA_LICENSE_KEY -p 8181:8181 -v $$(pwd):/cwd -w /cwd ko.local/enterprise-opa-private:edge run --server --log-level debug
+	docker run -p 8181:8181 -v $$(pwd):/cwd -w /cwd ko.local/enterprise-opa-private:edge run --server --log-level debug
 
 # build local container image (tagged)
 build-local:

--- a/e2e/batchquery/logs_test.go
+++ b/e2e/batchquery/logs_test.go
@@ -305,10 +305,6 @@ func loadEnterpriseOPA(t *testing.T, httpPort int, config string) (*exec.Cmd, *b
 	eopa := exec.Command(bin, args...)
 	eopa.Stderr = &stderr
 	eopa.Stdout = &stdout
-	eopa.Env = append(eopa.Environ(),
-		"EOPA_LICENSE_TOKEN="+os.Getenv("EOPA_LICENSE_TOKEN"),
-		"EOPA_LICENSE_KEY="+os.Getenv("EOPA_LICENSE_KEY"),
-	)
 
 	t.Cleanup(func() {
 		if eopa.Process == nil {

--- a/e2e/cli/Makefile
+++ b/e2e/cli/Makefile
@@ -1,4 +1,4 @@
-DOCKER:=docker run -e EOPA_LICENSE_TOKEN -v $$(pwd):/w -w /w --user root $(IMAGE)
+DOCKER:=docker run -v $$(pwd):/w -w /w --user root $(IMAGE)
 
 .PHONY: test
 test:

--- a/e2e/compile/e2e_test.go
+++ b/e2e/compile/e2e_test.go
@@ -810,10 +810,6 @@ func loadEnterpriseOPA(t *testing.T, httpPort int, config string) (*exec.Cmd, *b
 	eopa := exec.Command(bin, args...)
 	eopa.Stderr = &stderr
 	eopa.Stdout = &stdout
-	eopa.Env = append(eopa.Environ(),
-		"EOPA_LICENSE_TOKEN="+os.Getenv("EOPA_LICENSE_TOKEN"),
-		"EOPA_LICENSE_KEY="+os.Getenv("EOPA_LICENSE_KEY"),
-	)
 
 	t.Cleanup(func() {
 		if eopa.Process == nil {

--- a/e2e/data/git/git_test.go
+++ b/e2e/data/git/git_test.go
@@ -280,10 +280,6 @@ func eopaRun(t *testing.T, config, policy string, httpPort int, extra ...string)
 	}
 	eopa := exec.Command(binary(), args...)
 	eopa.Stderr = &buf
-	eopa.Env = append(eopa.Environ(),
-		"EOPA_LICENSE_TOKEN="+os.Getenv("EOPA_LICENSE_TOKEN"),
-		"EOPA_LICENSE_KEY="+os.Getenv("EOPA_LICENSE_KEY"),
-	)
 
 	t.Cleanup(func() {
 		if eopa.Process == nil {

--- a/e2e/data/kafka/bundle_test.go
+++ b/e2e/data/kafka/bundle_test.go
@@ -235,10 +235,6 @@ func eopaRun(t *testing.T, config, policy string, httpPort int, extra ...string)
 	}
 	eopa := exec.Command(binary(), args...)
 	eopa.Stderr = &buf
-	eopa.Env = append(eopa.Environ(),
-		"EOPA_LICENSE_TOKEN="+os.Getenv("EOPA_LICENSE_TOKEN"),
-		"EOPA_LICENSE_KEY="+os.Getenv("EOPA_LICENSE_KEY"),
-	)
 
 	t.Cleanup(func() {
 		if eopa.Process == nil {

--- a/e2e/decision_logs/main_test.go
+++ b/e2e/decision_logs/main_test.go
@@ -930,8 +930,6 @@ func loadEnterpriseOPA(t *testing.T, config, policy string, httpPort int, opts .
 	eopa.Stderr = &stderr
 	eopa.Stdout = &stdout
 	eopa.Env = append(eopa.Environ(),
-		"EOPA_LICENSE_TOKEN="+os.Getenv("EOPA_LICENSE_TOKEN"),
-		"EOPA_LICENSE_KEY="+os.Getenv("EOPA_LICENSE_KEY"),
 		"OPA_DECISIONS_INTERMEDIATE_RESULTS=VALUE",
 	)
 

--- a/e2e/discovery/main_test.go
+++ b/e2e/discovery/main_test.go
@@ -69,7 +69,7 @@ func TestDiscovery(t *testing.T) {
 	} {
 		t.Run(tc.note, func(t *testing.T) {
 			config := config(tc.bundle, testserver.URL)
-			eopa, eopaOut := eopaRun(t, config, eopaHTTPPort, true)
+			eopa, eopaOut := eopaRun(t, config, eopaHTTPPort)
 			if err := eopa.Start(); err != nil {
 				t.Fatal(err)
 			}
@@ -96,7 +96,7 @@ func TestDiscovery(t *testing.T) {
 	}
 }
 
-func eopaRun(t *testing.T, config string, httpPort int, includeEnv bool) (*exec.Cmd, *bytes.Buffer) {
+func eopaRun(t *testing.T, config string, httpPort int) (*exec.Cmd, *bytes.Buffer) {
 	buf := bytes.Buffer{}
 	dir := t.TempDir()
 	args := []string{
@@ -115,12 +115,6 @@ func eopaRun(t *testing.T, config string, httpPort int, includeEnv bool) (*exec.
 	}
 	eopa := exec.Command(binary(), args...)
 	eopa.Stderr = &buf
-	if includeEnv {
-		eopa.Env = append(eopa.Environ(),
-			"EOPA_LICENSE_TOKEN="+os.Getenv("EOPA_LICENSE_TOKEN"),
-			"EOPA_LICENSE_KEY="+os.Getenv("EOPA_LICENSE_KEY"),
-		)
-	}
 
 	t.Cleanup(func() {
 		if eopa.Process == nil {

--- a/e2e/ekm/bundle/main_test.go
+++ b/e2e/ekm/bundle/main_test.go
@@ -114,9 +114,6 @@ func startVaultServer(t *testing.T) *testcontainervault.VaultContainer {
 	if err := setKey(vlogical, "kv/data/acmecorp:data/url", map[string]any{"url": testserver.URL}); err != nil {
 		t.Fatal(err)
 	}
-	if err := setKey(vlogical, "kv/data/license:data/key", map[string]any{"key": os.Getenv("EOPA_LICENSE_KEY")}); err != nil {
-		t.Fatal(err)
-	}
 	dat, err := os.ReadFile("testdata/public_key.pem")
 	if err != nil {
 		t.Fatal(err)
@@ -144,10 +141,6 @@ func eopaRun(t *testing.T, extraArgs ...string) (*exec.Cmd, *bytes.Buffer) {
 	args = append(args, extraArgs...)
 	eopa := exec.Command(binary(), args...)
 	eopa.Stderr = &buf
-	eopa.Env = append(eopa.Environ(),
-		"EOPA_LICENSE_TOKEN="+os.Getenv("EOPA_LICENSE_TOKEN"),
-		"EOPA_LICENSE_KEY="+os.Getenv("EOPA_LICENSE_KEY"),
-	)
 
 	t.Cleanup(func() {
 		if eopa.Process == nil {

--- a/e2e/ekm/discovery/main_test.go
+++ b/e2e/ekm/discovery/main_test.go
@@ -201,9 +201,6 @@ func startVaultServer(t *testing.T, ctx context.Context) *testcontainervault.Vau
 	if err := setKey(vlogical, "kv/data/acmecorp:data/url", map[string]any{"url": testserver.URL}); err != nil {
 		t.Fatal(err)
 	}
-	if err := setKey(vlogical, "kv/data/license:data/key", map[string]any{"key": os.Getenv("EOPA_LICENSE_KEY")}); err != nil {
-		t.Fatal(err)
-	}
 	dat, err := os.ReadFile("testdata/public_key.pem")
 	if err != nil {
 		t.Fatal(err)
@@ -241,10 +238,6 @@ func eopaRun(t *testing.T, httpPort int, config []byte) (*exec.Cmd, *bytes.Buffe
 	eopa := exec.Command(binary(), args...)
 	eopa.Stderr = &buf
 	eopa.Stdout = &std
-	eopa.Env = append(eopa.Environ(),
-		"EOPA_LICENSE_TOKEN="+os.Getenv("EOPA_LICENSE_TOKEN"),
-		"EOPA_LICENSE_KEY="+os.Getenv("EOPA_LICENSE_KEY"),
-	)
 
 	t.Cleanup(func() {
 		if eopa.Process == nil {

--- a/e2e/grpc/main_test.go
+++ b/e2e/grpc/main_test.go
@@ -367,10 +367,6 @@ func eopaRun(t *testing.T, policy, data, config string, httpPort int, extraArgs 
 	}
 	eopa := exec.Command(binary(), args...)
 	eopa.Stderr = &buf
-	eopa.Env = append(eopa.Environ(),
-		"EOPA_LICENSE_TOKEN="+os.Getenv("EOPA_LICENSE_TOKEN"),
-		"EOPA_LICENSE_KEY="+os.Getenv("EOPA_LICENSE_KEY"),
-	)
 
 	t.Cleanup(func() {
 		if eopa.Process == nil {

--- a/e2e/impact/main_test.go
+++ b/e2e/impact/main_test.go
@@ -627,10 +627,6 @@ func loadEnterpriseOPA(t *testing.T, config, policy string, httpPort int, opts .
 	}
 	eopa := exec.Command(binary(), append(args, policyPath)...)
 	eopa.Stderr = &buf
-	eopa.Env = append(eopa.Environ(),
-		"EOPA_LICENSE_TOKEN="+os.Getenv("EOPA_LICENSE_TOKEN"),
-		"EOPA_LICENSE_KEY="+os.Getenv("EOPA_LICENSE_KEY"),
-	)
 
 	t.Cleanup(func() {
 		if eopa.Process == nil {

--- a/e2e/opentelemetry/main_test.go
+++ b/e2e/opentelemetry/main_test.go
@@ -162,10 +162,6 @@ func loadEnterpriseOPA(t *testing.T, config, policy string, httpPort int) (*exec
 	eopa := exec.Command(binary(), append(args, policyPath)...)
 	eopa.Stderr = &stderr
 	eopa.Stdout = &stdout
-	eopa.Env = append(eopa.Environ(),
-		"EOPA_LICENSE_TOKEN="+os.Getenv("EOPA_LICENSE_TOKEN"),
-		"EOPA_LICENSE_KEY="+os.Getenv("EOPA_LICENSE_KEY"),
-	)
 
 	t.Cleanup(func() {
 		if eopa.Process == nil {

--- a/e2e/preview/main_test.go
+++ b/e2e/preview/main_test.go
@@ -207,10 +207,6 @@ func loadEnterpriseOPA(t *testing.T, policy string, httpPort int) (*exec.Cmd, *b
 	}
 	eopa := exec.Command(binary(), append(args, policyPath)...)
 	eopa.Stderr = &buf
-	eopa.Env = append(eopa.Environ(),
-		"EOPA_LICENSE_TOKEN="+os.Getenv("EOPA_LICENSE_TOKEN"),
-		"EOPA_LICENSE_KEY="+os.Getenv("EOPA_LICENSE_KEY"),
-	)
 
 	t.Cleanup(func() {
 		if eopa.Process == nil {


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

This PR removes all references to the `EOPA_LICENSE_{TOKEN,KEY}` environment variables from both our workflows and E2E tests.

### :+1: Definition of done

### :athletic_shoe: How to test

### :chains: Related Resources
