### PR TITLE
ci: Add permissions to linting in PR workflow.

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -24,6 +24,9 @@ jobs:
     name: Analysis & Linting
     needs: prereqs
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Tune GitHub-hosted runner network
         uses: smorimoto/tune-github-hosted-runner-network@bb252dcb5c8609a31087e7993daa086f5a1c0069 # v1.0.0


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

This PR adds permissions that Dependabot may need for running our linting GHA workflow for pull requests.

### :athletic_shoe: How to test

 - Does CI run on this PR?
 - Does CI work properly for Dependabot after we merge this? :sweat_smile: 

### :chains: Related Resources
