### PR TITLE
ci: Add permissions blocks to ko build and protobuf docs push jobs.

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -296,6 +296,9 @@ jobs:
     name: Push Protobuf docs to BSR
     needs: prereqs
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Tune GitHub-hosted runner network
         uses: smorimoto/tune-github-hosted-runner-network@bb252dcb5c8609a31087e7993daa086f5a1c0069 # v1.0.0
@@ -330,6 +333,9 @@ jobs:
     name: Ko Build
     needs: prereqs
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Tune GitHub-hosted runner network
         uses: smorimoto/tune-github-hosted-runner-network@bb252dcb5c8609a31087e7993daa086f5a1c0069 # v1.0.0


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

This is a follow-up to #68, which un-broke the linting job for Dependabot. This PR fixes the other two jobs that use the [`dorny/paths-filter`](https://github.com/dorny/paths-filter) action, so that they'll work for the bot too.

### :athletic_shoe: How to test

 - Merge PR :arrow_right: See if the Dependabot PRs work again.

### :chains: Related Resources
