### PR TITLE
ci: Retarget CI prereqs job to use StyraOSS version.

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Prereqs
     runs-on: ubuntu-24.04
     steps:
-      - uses: StyraInc/styra-init-action@main
+      - uses: StyraOSS/styra-init-action@main
 
   benchmarks:
     name: Benchmarks

--- a/.github/workflows/branch-cache-cleanup.yaml
+++ b/.github/workflows/branch-cache-cleanup.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Prereqs
     runs-on: ubuntu-24.04
     steps:
-      - uses: StyraInc/styra-init-action@main
+      - uses: StyraOSS/styra-init-action@main
 
   cleanup:
     needs: prereqs

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Prereqs
     runs-on: ubuntu-24.04
     steps:
-      - uses: StyraInc/styra-init-action@main
+      - uses: StyraOSS/styra-init-action@main
 
   goreleaser:
     name: GoReleaser

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Prereqs
     runs-on: ubuntu-24.04
     steps:
-      - uses: StyraInc/styra-init-action@main
+      - uses: StyraOSS/styra-init-action@main
 
   build:
     name: Build and Test

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Prereqs
     runs-on: ubuntu-24.04
     steps:
-      - uses: StyraInc/styra-init-action@main
+      - uses: StyraOSS/styra-init-action@main
 
   lint:
     name: Analysis & Linting

--- a/.github/workflows/push-main.yaml
+++ b/.github/workflows/push-main.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Prereqs
     runs-on: ubuntu-24.04
     steps:
-      - uses: StyraInc/styra-init-action@main
+      - uses: StyraOSS/styra-init-action@main
 
   deploy:
     name: Push Latest Release

--- a/.github/workflows/push-tags.yaml
+++ b/.github/workflows/push-tags.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Prereqs
     runs-on: ubuntu-24.04
     steps:
-      - uses: StyraInc/styra-init-action@main
+      - uses: StyraOSS/styra-init-action@main
 
   # goreleaser:
   #   name: GoReleaser

--- a/.github/workflows/update-base.yaml
+++ b/.github/workflows/update-base.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Prereqs
     runs-on: ubuntu-24.04
     steps:
-      - uses: StyraInc/styra-init-action@main
+      - uses: StyraOSS/styra-init-action@main
 
   deploy:
     name: Build and push base images

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -4,4 +4,4 @@ files:
   - pattern: "^\\.github/workflows/.*\\.ya?ml$"
 
 ignore_actions:
-  - name: StyraInc/styra-init-action
+  - name: StyraOSS/styra-init-action


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

This commit retargets our CI init-action job to use the version in the same Github Org as the current EOPA repo.

### :athletic_shoe: How to test

 - Does CI run at all again? If yes, we're good!

### :chains: Related Resources
