### PR TITLE
compile: rename internal-only sqlite builtins

### DIFF
--- a/e2e/cli/test/testdata/test_rego_compile_sqlite_like.txtar
+++ b/e2e/cli/test/testdata/test_rego_compile_sqlite_like.txtar
@@ -3,9 +3,9 @@
 # that: the translation of startwith into LIKE would therefore
 # be incorrect.
 # Instead, we have internal-only builtins
-#  * styra_startswith(string, string): bool
-#  * styra_endswith(string, string): bool
-#  * styra_contains(string, string): bool
+#  * internal_startswith(string, string): bool
+#  * internal_endswith(string, string): bool
+#  * internal_contains(string, string): bool
 # which check their strings case-sensitively.
 exec eopa test .
 ! stderr .

--- a/pkg/builtins/sqlsend.go
+++ b/pkg/builtins/sqlsend.go
@@ -549,9 +549,9 @@ func init() {
 	snowflake.GetLogger().SetOutput(io.Discard)
 
 	// register our styra-internal functions
-	sqlite.RegisterDeterministicScalarFunction("styra_startswith", 2, arity2StringFunc(strings.HasPrefix))
-	sqlite.RegisterDeterministicScalarFunction("styra_endswith", 2, arity2StringFunc(strings.HasSuffix))
-	sqlite.RegisterDeterministicScalarFunction("styra_contains", 2, arity2StringFunc(strings.Contains))
+	sqlite.RegisterDeterministicScalarFunction("internal_startswith", 2, arity2StringFunc(strings.HasPrefix))
+	sqlite.RegisterDeterministicScalarFunction("internal_endswith", 2, arity2StringFunc(strings.HasSuffix))
+	sqlite.RegisterDeterministicScalarFunction("internal_contains", 2, arity2StringFunc(strings.Contains))
 }
 
 // Suppress error messages from Go MySQL driver like "[mysql] 2023/07/27 15:59:30 packets.go:37: unexpected EOF"

--- a/pkg/ucast/ucast.go
+++ b/pkg/ucast/ucast.go
@@ -118,7 +118,7 @@ func (u *UCASTNode) asSQL(cond *sqlbuilder.Cond, dialect string) (string, error)
 			return "", fmt.Errorf("field operator 'in' requires collection argument")
 		case "startswith":
 			if dialect == "sqlite-internal" {
-				return cond.Var(sqlbuilder.Build("styra_startswith($?, $?)", sqlbuilder.Raw(field), value)), nil
+				return cond.Var(sqlbuilder.Build("internal_startswith($?, $?)", sqlbuilder.Raw(field), value)), nil
 			}
 			pattern, err := prefix(value)
 			if err != nil {
@@ -127,7 +127,7 @@ func (u *UCASTNode) asSQL(cond *sqlbuilder.Cond, dialect string) (string, error)
 			return cond.Like(field, pattern), nil
 		case "endswith":
 			if dialect == "sqlite-internal" {
-				return cond.Var(sqlbuilder.Build("styra_endswith($?, $?)", sqlbuilder.Raw(field), value)), nil
+				return cond.Var(sqlbuilder.Build("internal_endswith($?, $?)", sqlbuilder.Raw(field), value)), nil
 			}
 			pattern, err := suffix(value)
 			if err != nil {
@@ -136,7 +136,7 @@ func (u *UCASTNode) asSQL(cond *sqlbuilder.Cond, dialect string) (string, error)
 			return cond.Like(field, pattern), nil
 		case "contains":
 			if dialect == "sqlite-internal" {
-				return cond.Var(sqlbuilder.Build("styra_contains($?, $?)", sqlbuilder.Raw(field), value)), nil
+				return cond.Var(sqlbuilder.Build("internal_contains($?, $?)", sqlbuilder.Raw(field), value)), nil
 			}
 			pattern, err := infix(value)
 			if err != nil {


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

It's supposed to not clash with anything in SQLite. Before, we called it `styra_startswith` etc, now we call it `internal_startswith`.

### :+1: Definition of done

Tests pass.

