### PR TITLE
build: fix EOPA_VERSION in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,7 @@ RELEASE_NOTES ?= "release-notes.md"
 EXAMPLES := $(wildcard examples/*)
 
 # EOPA_VERSION: strip 'v' from tag
-# TODO(sr): Go back to this when we go back to pushing tags: $(shell git describe --abbrev=0 --tags | sed s/^v//)
-export EOPA_VERSION := 0.0.1
+export EOPA_VERSION := $(shell git describe --abbrev=0 --tags | sed s/^v//)
 VERSION := $(EOPA_VERSION)$(shell ./build/get-plugin-rev.sh)
 export OPA_VERSION := $(shell ./build/get-opa-version.sh)
 HOSTNAME ?= $(shell hostname -f)


### PR DESCRIPTION
We've been pushing another :0.0.1 image for #112 😬 I had forgotten to revert that bit in the Makefile.