### PR TITLE
pkg/batchquery: Fix potential panic in authorizer pathfunc.

### DIFF
--- a/pkg/batchquery/handler.go
+++ b/pkg/batchquery/handler.go
@@ -84,6 +84,9 @@ func (h *hndl) SetManager(m *plugins.Manager) error {
 	m.ExtraRoute("POST /v1/batch/data/{path...}", PrometheusHandle, h.ServeHTTP)
 	m.ExtraRoute("POST /v1/batch/data", PrometheusHandle, h.ServeHTTP)
 	m.ExtraAuthorizerRoute(func(method string, path []any) bool {
+		if len(path) < 3 {
+			return false
+		}
 		s0 := path[0].(string)
 		s1 := path[1].(string)
 		s2 := path[2].(string)


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

This commit fixes a potential issue where the path validation function provided to OPA's authorizer could panic from attempting an out-of-bounds slice index on the path parts slice.

The reason our tests failed to catch this seems to be that almost none of our 

### :+1: Definition of done

### :athletic_shoe: How to test

- Use this authorization policy, `auth.rego`:
```rego
package system.authz

import rego.v1

default allow := false

allow if {
	input.identity == ["secret", "supersecret", "superdupersecret"][_]
}

allow if {
	input.path == ["health"]
}
```

 - Run the docker image, specifically:
 ```shell
docker run --rm -it -p 8181:8181 -v ${PWD}:/work -w /work --user $(id -u):$(id -g) ghcr.io/open-policy-agent/eopa:latest run -s --disable-telemetry --log-level=debug --addr=0.0.0.0:8181 --authentication=token --authorization=basic auth.rego
```

 - `curl http://localhost:8181/health`
 - Observe no response to curl, panic on the EOPA window.
   ```
   curl: (52) Empty reply from server
   ```

### :chains: Related Resources
