### PR TITLE
README: Fix OPA community Slack link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A version of OPA designed for data heavy workloads, with data-filtering function
 **EOPA has been donated to the OPA community**, and we invite you to take a look around.
 
 - Try EOPA if you have to integrate with databases including DynamoDB, Postgres, and Neo4j. See the full list [here](./docs/eopa/_eopa-introduction.md)
-- Experiment with EOPA's performance improvements and share feedback in `#help` on [Slack](slack.openpolicyagent.org)
+- Experiment with EOPA's performance improvements and share feedback in `#help` on [Slack](https://slack.openpolicyagent.org/)
 - See the [A Note from Teemu, Tim and Torin](https://blog.openpolicyagent.org/note-from-teemu-tim-and-torin-to-the-open-policy-agent-community-2dbbfe494371)
   for more information.
 


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

The Slack community link accidentally pointed *inside the repo*, instead of to the actual `openpolicyagent.org` subdomain. 🙃 This PR fixes the typo.
