### PR TITLE
workflows/goreleaser: add missing env var

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -66,3 +66,4 @@ jobs:
           TAP_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_NOTES: ../release-notes.md
+          EOPA_GH_REPO: open-policy-agent/eopa


### PR DESCRIPTION
This branch was used to push the GitHub release of v1.45.0