### PR TITLE
Allow role configuration in decision_log s3Output

### DIFF
--- a/internal/benthos/impl/aws/output_s3.go
+++ b/internal/benthos/impl/aws/output_s3.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
-
 	"github.com/redpanda-data/benthos/v4/public/bloblang"
 	"github.com/redpanda-data/benthos/v4/public/service"
 
@@ -282,6 +281,7 @@ func init() {
 			}
 			var wConf s3oConfig
 			if wConf, err = s3oConfigFromParsed(conf); err != nil {
+				mgr.Logger().Errorf("failed to parse S3 output config: %v", err)
 				return
 			}
 			out, err = newAmazonS3Writer(wConf, mgr)
@@ -432,6 +432,7 @@ func (a *amazonS3Writer) WriteBatch(wctx context.Context, msg service.MessageBat
 		}
 
 		if _, err := a.uploader.Upload(ctx, uploadInput); err != nil {
+			a.log.Errorf("failed to upload object to S3: %v", err)
 			return err
 		}
 		return nil

--- a/internal/benthos/impl/aws/session.go
+++ b/internal/benthos/impl/aws/session.go
@@ -50,10 +50,6 @@ func GetSession(ctx context.Context, parsedConf *service.ParsedConfig, opts ...f
 		return conf, err
 	}
 
-	if endpoint, _ := parsedConf.FieldString("endpoint"); endpoint != "" {
-		conf.BaseEndpoint = &endpoint
-	}
-
 	if role, _ := credsConf.FieldString("role"); role != "" {
 		stsSvc := sts.NewFromConfig(conf)
 
@@ -66,6 +62,10 @@ func GetSession(ctx context.Context, parsedConf *service.ParsedConfig, opts ...f
 
 		creds := stscreds.NewAssumeRoleProvider(stsSvc, role, stsOpts...)
 		conf.Credentials = aws.NewCredentialsCache(creds)
+	}
+
+	if endpoint, _ := parsedConf.FieldString("endpoint"); endpoint != "" {
+		conf.BaseEndpoint = &endpoint
 	}
 
 	if useEC2, _ := credsConf.FieldBool("from_ec2_role"); useEC2 {

--- a/internal/benthos/impl/aws/session.go
+++ b/internal/benthos/impl/aws/session.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"net/http"
+	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -10,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
-
+	"github.com/aws/smithy-go/logging"
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
@@ -38,6 +39,11 @@ func GetSession(ctx context.Context, parsedConf *service.ParsedConfig, opts ...f
 			id, secret, token,
 		)))
 	}
+
+	// Enable AWS SDK logging to stderr for debugging purposes
+	//TODO remove after debugging
+	opts = append(opts, config.WithClientLogMode(aws.LogRequestWithBody|aws.LogResponseWithBody))
+	opts = append(opts, config.WithLogger(logging.NewStandardLogger(os.Stderr)))
 
 	conf, err := config.LoadDefaultConfig(ctx, opts...)
 	if err != nil {

--- a/pkg/plugins/decision_logs/config.go
+++ b/pkg/plugins/decision_logs/config.go
@@ -478,8 +478,11 @@ type outputS3Opts struct {
 	Region       string `json:"region"`
 	ForcePath    bool   `json:"force_path"`
 	Bucket       string `json:"bucket"`
-	AccessKeyID  string `json:"access_key_id"`
-	AccessSecret string `json:"access_secret"`
+	AccessKeyID  string `json:"access_key_id,omitempty"`
+	AccessSecret string `json:"access_secret,omitempty"`
+	Role         string `json:"role,omitempty"`
+	ExternalId   string `json:"role_external_id,omitempty"`
+
 	// TODO(sr): support more automatic methods, ec2 role, kms etc
 
 	TLS      *tlsOpts   `json:"tls,omitempty"`
@@ -541,10 +544,17 @@ func (s *outputS3Opts) Benthos() map[string]any {
 	if s.tls != nil {
 		m["tls"] = s.tls.Benthos()
 	}
-	m["credentials"] = map[string]any{
+	cred := map[string]any{
 		"id":     s.AccessKeyID,
 		"secret": s.AccessSecret,
 	}
+	if s.Role != "" {
+		cred["role"] = s.Role
+	}
+	if s.ExternalId != "" {
+		cred["role_external_id"] = s.ExternalId
+	}
+	m["credentials"] = cred
 	return map[string]any{"aws_s3": m}
 }
 


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?
Allowed adding an aws role and external in eopa_dl S3 output configuration. This enables S3 output to use AssumeRoleProvider from aws-sdk-go-v2 in addition to the static credentials.

### :+1: Definition of done

### :athletic_shoe: How to test
Unit tests are added.

### :chains: Related Resources
