### PR TITLE
pkg: Fix deprecation warnings from upstream OPA.

### DIFF
--- a/pkg/plugins/grpc/grpc.go
+++ b/pkg/plugins/grpc/grpc.go
@@ -697,12 +697,6 @@ func getRevisions(ctx context.Context, store storage.Store, txn storage.Transact
 	var br bundleRevisions
 	br.Revisions = map[string]string{}
 
-	// Check if we still have a legacy bundle manifest in the store
-	br.LegacyRevision, err = bundle.LegacyReadRevisionFromStore(ctx, store, txn)
-	if err != nil && !storage.IsNotFound(err) {
-		return br, err
-	}
-
 	// read all bundle revisions from storage (if any exist)
 	names, err := bundle.ReadBundleNamesFromStore(ctx, store, txn)
 	if err != nil && !storage.IsNotFound(err) {


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

This PR fixes two deprecation warnings that occur after upgrading the OPA version for the project. Those were [blocking Dependabot](https://github.com/open-policy-agent/eopa/actions/runs/20280370552/job/58240417924?pr=260) from auto-merging some version upgrades for us automatically.

These deprecations are:
 - `v1/server/writer/writer.go`: `writer.JSON()`
 - `v1/bundle/store.go`: `bundle.LegacyReadRevisionFromStore()`

For the `writer.JSON` call, I pulled in the code from upstream, because we do need the efficiency of that implementation for Batch Queries, and we can generally ensure that the encoding error case is not going to happen.

For the `bundle.LegacyReadRevisionFromStore` call, it's removed from all live codepaths in upstream OPA, so we should be good to remove it here as well.

### :+1: Definition of done

 - Do the tests in CI all pass?

### :chains: Related Resources
