### PR TITLE
pkg/bjson+storage: Modernization, optimizations, and new features

### DIFF
--- a/pkg/json/array.go
+++ b/pkg/json/array.go
@@ -54,7 +54,7 @@ func (arraySliceBase[T]) extractImpl(a T, ptr []string) (Json, error) {
 
 func (arraySliceBase[T]) clone(a T, deepCopy bool) Array {
 	j := make([]File, a.Len())
-	for i := 0; i < len(j); i++ {
+	for i := range j {
 		v := a.valueImpl(i)
 		if deepCopy {
 			v = v.Clone(true)
@@ -65,9 +65,9 @@ func (arraySliceBase[T]) clone(a T, deepCopy bool) Array {
 	return NewArray(j, len(j))
 }
 
-func (arraySliceBase[T]) JSON(a T) interface{} {
-	array := make([]interface{}, a.Len())
-	for i := 0; i < len(array); i++ {
+func (arraySliceBase[T]) JSON(a T) any {
+	array := make([]any, a.Len())
+	for i := range array {
 		j, ok := a.valueImpl(i).(Json)
 		if ok {
 			array[i] = j.JSON()
@@ -79,7 +79,7 @@ func (arraySliceBase[T]) JSON(a T) interface{} {
 
 func (arraySliceBase[T]) AST(a T) ast.Value {
 	array := make([]*ast.Term, a.Len())
-	for i := 0; i < len(array); i++ {
+	for i := range array {
 		j, ok := a.valueImpl(i).(Json)
 		if ok {
 			array[i] = ast.NewTerm(j.AST())
@@ -91,7 +91,7 @@ func (arraySliceBase[T]) AST(a T) ast.Value {
 
 func (arraySliceBase[T]) String(a T) string {
 	s := make([]string, a.Len())
-	for i := 0; i < len(s); i++ {
+	for i := range s {
 		s[i] = a.Value(i).String()
 	}
 	return "[" + strings.Join(s, ",") + "]"
@@ -193,7 +193,7 @@ func (a *ArraySliceCompact[T]) WriteTo(w io.Writer) (int64, error) {
 	return writeArrayJSON(w, a)
 }
 
-func (a *ArraySliceCompact[T]) Contents() interface{} {
+func (a *ArraySliceCompact[T]) Contents() any {
 	return a.JSON()
 }
 
@@ -226,11 +226,12 @@ func (a *ArraySliceCompact[T]) append(elements ...File) Array {
 	m := a.n + len(elements)
 	n := make([]File, m)
 	j := 0
+	// TODO: Replace with 2x copy() calls?
 	for i := 0; i < a.n; i++ {
 		n[j] = a.elements[i]
 		j++
 	}
-	for i := 0; i < len(elements); i++ {
+	for i := range elements {
 		n[j] = elements[i]
 		j++
 	}
@@ -245,7 +246,8 @@ func (a *ArraySliceCompact[T]) append(elements ...File) Array {
 
 func (a *ArraySliceCompact[T]) Slice(i, j int) Array {
 	elements := make([]File, j-i)
-	for k := 0; k < len(elements); k++ {
+	// TODO: Replace this with copy()?
+	for k := range elements {
 		elements[k] = a.elements[i+k]
 	}
 
@@ -288,6 +290,7 @@ func (a *ArraySliceCompact[T]) RemoveIdx(i int) Json {
 		return zeroArray
 	}
 
+	// TODO: Replace this with copy() + nil the last element?
 	for ; i < a.n-1; i++ {
 		a.elements[i] = a.elements[i+1]
 	}
@@ -306,7 +309,7 @@ func (a *ArraySliceCompact[T]) SetIdx(i int, j File) Json {
 	return a
 }
 
-func (a *ArraySliceCompact[T]) JSON() interface{} {
+func (a *ArraySliceCompact[T]) JSON() any {
 	return arraySliceBase[*ArraySliceCompact[T]]{}.JSON(a)
 }
 

--- a/pkg/json/array_diff.go
+++ b/pkg/json/array_diff.go
@@ -34,7 +34,7 @@ func arrayDiff(a contentReader, ar arrayReader, b contentReader, br arrayReader,
 	bh := make(map[uint64][]int, bl)
 	bhl := make([]uint64, bl)
 
-	for i := 0; i < al; i++ {
+	for i := range al {
 		off, err := ar.ArrayValueOffset(i)
 		if err != nil {
 			return nil, false, err
@@ -50,7 +50,7 @@ func arrayDiff(a contentReader, ar arrayReader, b contentReader, br arrayReader,
 		ah[h] = append(ah[h], i)
 	}
 
-	for i := 0; i < bl; i++ {
+	for i := range bl {
 		off, err := br.ArrayValueOffset(i)
 		if err != nil {
 			return nil, false, err
@@ -194,7 +194,7 @@ func elementEqual(a contentReader, aoff int64, b contentReader, boff int64) (boo
 			return false, nil
 		}
 
-		for i := 0; i < al; i++ {
+		for i := range al {
 			aoff, err := aa.ArrayValueOffset(i)
 			if err != nil {
 				return false, err

--- a/pkg/json/array_diff_test.go
+++ b/pkg/json/array_diff_test.go
@@ -31,13 +31,13 @@ type ai struct {
 }
 
 func testArrayDiff(t *testing.T, a string, b string, result []ai) {
-	var data1 interface{}
+	var data1 any
 	err := gojson.Unmarshal([]byte(a), &data1)
 	if err != nil {
 		t.Fatalf("Unable to unmarshal: %v", err)
 	}
 
-	var data2 interface{}
+	var data2 any
 	err = gojson.Unmarshal([]byte(b), &data2)
 	if err != nil {
 		t.Fatalf("Unable to unmarshal: %v", err)
@@ -84,7 +84,7 @@ func testArrayDiff(t *testing.T, a string, b string, result []ai) {
 		t.Fatalf("diff resulted in wrong results: %d vs %d, %v", len(ai), len(result), changed)
 	}
 
-	for i := 0; i < len(ai); i++ {
+	for i := range ai {
 		if ai[i].b != result[i].b {
 			t.Fatalf("diff did not detect value reuse")
 		}
@@ -259,13 +259,13 @@ func TestHashCache(t *testing.T) {
 }
 
 func testEqual(t *testing.T, a string, b string) {
-	var data1 interface{}
+	var data1 any
 	err := gojson.Unmarshal([]byte(a), &data1)
 	if err != nil {
 		t.Fatalf("Unable to unmarshal: %v", err)
 	}
 
-	var data2 interface{}
+	var data2 any
 	err = gojson.Unmarshal([]byte(b), &data2)
 	if err != nil {
 		t.Fatalf("Unable to unmarshal: %v", err)

--- a/pkg/json/array_strings.go
+++ b/pkg/json/array_strings.go
@@ -113,7 +113,7 @@ func (a *ArraySliceCompactStrings[T]) WriteTo(w io.Writer) (int64, error) {
 	return writeArrayJSON(w, a)
 }
 
-func (a *ArraySliceCompactStrings[T]) Contents() interface{} {
+func (a *ArraySliceCompactStrings[T]) Contents() any {
 	return a.JSON()
 }
 
@@ -159,7 +159,7 @@ func (a *ArraySliceCompactStrings[T]) append(elements ...File) Array {
 		n[j] = a.elements[i]
 		j++
 	}
-	for i := 0; i < len(elements); i++ {
+	for i := range elements {
 		n[j] = elements[i]
 		j++
 	}
@@ -174,7 +174,7 @@ func (a *ArraySliceCompactStrings[T]) append(elements ...File) Array {
 
 func (a *ArraySliceCompactStrings[T]) Slice(i, j int) Array {
 	elements := make([]File, j-i)
-	for k := 0; k < len(elements); k++ {
+	for k := range elements {
 		elements[k] = a.elements[i+k]
 	}
 
@@ -234,7 +234,7 @@ func (a *ArraySliceCompactStrings[T]) SetIdx(i int, j File) Json {
 	}
 
 	f := make([]File, a.Len())
-	for k := 0; k < len(f); k++ {
+	for k := range f {
 		if k == i {
 			f[k] = j
 		} else {
@@ -245,7 +245,7 @@ func (a *ArraySliceCompactStrings[T]) SetIdx(i int, j File) Json {
 	return NewArray(f, len(f))
 }
 
-func (a *ArraySliceCompactStrings[T]) JSON() interface{} {
+func (a *ArraySliceCompactStrings[T]) JSON() any {
 	return arraySliceBase[*ArraySliceCompactStrings[T]]{}.JSON(a)
 }
 

--- a/pkg/json/array_strings_test.go
+++ b/pkg/json/array_strings_test.go
@@ -59,7 +59,7 @@ func TestArrayStringsSizes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			var native interface{}
+			var native any
 			if err := json.NewDecoder(bytes.NewBufferString(test.json)).Decode(&native); err != nil {
 				t.Fatal(err)
 			}
@@ -75,7 +75,7 @@ func TestArrayStringsSizes(t *testing.T) {
 				t.Errorf("incorrect json marshaling: %s", doc.String())
 			}
 
-			var nativeArr = native.([]interface{})
+			var nativeArr = native.([]any)
 			var arr = doc.(Array)
 
 			arr = arr.Clone(true).(Array)
@@ -122,14 +122,14 @@ func TestArrayStringsSizes(t *testing.T) {
 				arr = a
 			}
 
-			if !reflect.DeepEqual(arr.JSON(), append(nativeArr, []interface{}{"a", "b", "c"}...)) {
+			if !reflect.DeepEqual(arr.JSON(), append(nativeArr, []any{"a", "b", "c"}...)) {
 				t.Error("broken append or append single")
 			}
 
 			// SetIdx, RemoveIdx
 
 			arr = arr.SetIdx(arr.Len()-1, NewString("c updated")).(Array)
-			if !reflect.DeepEqual(arr.JSON(), append(nativeArr, []interface{}{"a", "b", "c updated"}...)) {
+			if !reflect.DeepEqual(arr.JSON(), append(nativeArr, []any{"a", "b", "c updated"}...)) {
 				t.Error("broken set idx")
 			}
 
@@ -146,9 +146,9 @@ func TestArrayStringsSizes(t *testing.T) {
 // TestArrayStringsAppend stresses the append implementation.
 func TestArrayStringsAppend(t *testing.T) {
 	arr := newArrayCompactStrings[[1]*String](nil)
-	var expected []interface{}
+	expected := make([]any, 0, 64*2)
 
-	for i := int64(0); i < 64; i++ {
+	for i := range int64(64) {
 		arr = arr.Append(NewString(fmt.Sprintf("%d", i)), NewString(fmt.Sprintf("%d", i*2)))
 		expected = append(expected, fmt.Sprintf("%d", i))
 		expected = append(expected, fmt.Sprintf("%d", i*2))

--- a/pkg/json/array_test.go
+++ b/pkg/json/array_test.go
@@ -60,7 +60,7 @@ func TestArraySizes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			var native interface{}
+			var native any
 			if err := util.NewJSONDecoder(bytes.NewBufferString(test.json)).Decode(&native); err != nil {
 				t.Fatal(err)
 			}
@@ -76,7 +76,7 @@ func TestArraySizes(t *testing.T) {
 				t.Errorf("incorrect json marshaling: %s", doc.String())
 			}
 
-			var nativeArr = native.([]interface{})
+			var nativeArr = native.([]any)
 			var arr = doc.(Array)
 
 			arr = arr.Clone(true).(Array)
@@ -123,14 +123,14 @@ func TestArraySizes(t *testing.T) {
 				arr = a
 			}
 
-			if !reflect.DeepEqual(arr.JSON(), append(nativeArr, []interface{}{"a", "b", "c"}...)) {
+			if !reflect.DeepEqual(arr.JSON(), append(nativeArr, []any{"a", "b", "c"}...)) {
 				t.Error("broken append or append single")
 			}
 
 			// SetIdx, RemoveIdx
 
 			arr = arr.SetIdx(arr.Len()-1, NewString("c updated")).(Array)
-			if !reflect.DeepEqual(arr.JSON(), append(nativeArr, []interface{}{"a", "b", "c updated"}...)) {
+			if !reflect.DeepEqual(arr.JSON(), append(nativeArr, []any{"a", "b", "c updated"}...)) {
 				t.Error("broken set idx")
 			}
 
@@ -147,9 +147,9 @@ func TestArraySizes(t *testing.T) {
 // TestArrayAppend stresses the append implementation.
 func TestArrayAppend(t *testing.T) {
 	arr := NewArray(nil, 1)
-	var expected []interface{}
+	expected := make([]any, 0, 64*2)
 
-	for i := int64(0); i < 64; i++ {
+	for i := range int64(64) {
 		arr = arr.Append(NewFloatInt(i), NewFloatInt(i*2))
 		expected = append(expected, json.Number(fmt.Sprintf("%d", i)))
 		expected = append(expected, json.Number(fmt.Sprintf("%d", i*2)))

--- a/pkg/json/blob.go
+++ b/pkg/json/blob.go
@@ -33,7 +33,7 @@ func (b *blobImpl) WriteTo(w io.Writer) (int64, error) {
 	return int64(n), err
 }
 
-func (b *blobImpl) Contents() interface{} {
+func (b *blobImpl) Contents() any {
 	return b.Value()
 }
 

--- a/pkg/json/blob_test.go
+++ b/pkg/json/blob_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/open-policy-agent/eopa/pkg/json/internal/utils"
+	"github.com/open-policy-agent/eopa/pkg/json/utils"
 )
 
 func TestBlob(t *testing.T) {
@@ -36,7 +36,7 @@ func TestBlob(t *testing.T) {
 	}
 }
 
-func buildBinary(data interface{}) (File, error) {
+func buildBinary(data any) (File, error) {
 	cache := newEncodingCache()
 	buffer := new(bytes.Buffer)
 

--- a/pkg/json/compare.go
+++ b/pkg/json/compare.go
@@ -76,7 +76,7 @@ func equalOp(a, b Json) bool {
 	}
 }
 
-func equalObject(a, b interface{}) bool {
+func equalObject(a, b any) bool {
 	switch a := a.(type) {
 	case Object:
 		switch b := b.(type) {

--- a/pkg/json/compare_test.go
+++ b/pkg/json/compare_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func testJSONCompare(t *testing.T, a interface{}, b interface{}, expected int) {
+func testJSONCompare(t *testing.T, a any, b any, expected int) {
 	x, err1 := buildJSON(a)
 	y, err2 := buildJSON(b)
 	if err1 != nil || err2 != nil {
@@ -41,20 +41,20 @@ func TestJSONCompare(t *testing.T) {
 
 	// Arrays
 
-	testJSONCompare(t, []interface{}{}, []interface{}{"foo"}, -1)
-	testJSONCompare(t, []interface{}{}, []interface{}{}, 0)
-	testJSONCompare(t, []interface{}{"foo"}, []interface{}{"foo"}, 0)
-	testJSONCompare(t, []interface{}{"foo"}, []interface{}{}, 1)
+	testJSONCompare(t, []any{}, []any{"foo"}, -1)
+	testJSONCompare(t, []any{}, []any{}, 0)
+	testJSONCompare(t, []any{"foo"}, []any{"foo"}, 0)
+	testJSONCompare(t, []any{"foo"}, []any{}, 1)
 
 	// Maps (and interfaces as values).
 
-	testJSONCompare(t, map[string]interface{}{}, map[string]interface{}{"key1": "foo"}, -1)
-	testJSONCompare(t, map[string]interface{}{"key1": "foo"}, map[string]interface{}{"key1": "foo"}, 0)
-	testJSONCompare(t, map[string]interface{}{"key1": "foo"}, map[string]interface{}{}, 1)
+	testJSONCompare(t, map[string]any{}, map[string]any{"key1": "foo"}, -1)
+	testJSONCompare(t, map[string]any{"key1": "foo"}, map[string]any{"key1": "foo"}, 0)
+	testJSONCompare(t, map[string]any{"key1": "foo"}, map[string]any{}, 1)
 
-	testJSONCompare(t, map[string]interface{}{"key1": "foo", "key2": "bar0"}, map[string]interface{}{"key1": "foo", "key2": "bar1"}, -1)
-	testJSONCompare(t, map[string]interface{}{"key1": "foo", "key2": "bar"}, map[string]interface{}{"key1": "foo", "key2": "bar"}, 0)
-	testJSONCompare(t, map[string]interface{}{"key1": "foo", "key2": "bar1"}, map[string]interface{}{"key1": "foo", "key2": "bar0"}, 1)
+	testJSONCompare(t, map[string]any{"key1": "foo", "key2": "bar0"}, map[string]any{"key1": "foo", "key2": "bar1"}, -1)
+	testJSONCompare(t, map[string]any{"key1": "foo", "key2": "bar"}, map[string]any{"key1": "foo", "key2": "bar"}, 0)
+	testJSONCompare(t, map[string]any{"key1": "foo", "key2": "bar1"}, map[string]any{"key1": "foo", "key2": "bar0"}, 1)
 
 	// Mixed types
 
@@ -65,11 +65,11 @@ func TestJSONCompare(t *testing.T) {
 
 	// Binary types in arrays and objects
 
-	testJSONCompare(t, []interface{}{NewBlob([]byte("bar"))}, []interface{}{NewBlob([]byte("foo"))}, -1)
-	testJSONCompare(t, []interface{}{NewBlob([]byte("foo"))}, []interface{}{NewBlob([]byte("foo"))}, 0)
-	testJSONCompare(t, []interface{}{NewBlob([]byte("foo"))}, []interface{}{NewBlob([]byte("bar"))}, 1)
+	testJSONCompare(t, []any{NewBlob([]byte("bar"))}, []any{NewBlob([]byte("foo"))}, -1)
+	testJSONCompare(t, []any{NewBlob([]byte("foo"))}, []any{NewBlob([]byte("foo"))}, 0)
+	testJSONCompare(t, []any{NewBlob([]byte("foo"))}, []any{NewBlob([]byte("bar"))}, 1)
 
-	testJSONCompare(t, map[string]interface{}{"key1": NewBlob([]byte("bar"))}, map[string]interface{}{"key1": NewBlob([]byte("foo"))}, -1)
-	testJSONCompare(t, map[string]interface{}{"key1": NewBlob([]byte("foo"))}, map[string]interface{}{"key1": NewBlob([]byte("foo"))}, 0)
-	testJSONCompare(t, map[string]interface{}{"key1": NewBlob([]byte("foo"))}, map[string]interface{}{"key1": NewBlob([]byte("bar"))}, 1)
+	testJSONCompare(t, map[string]any{"key1": NewBlob([]byte("bar"))}, map[string]any{"key1": NewBlob([]byte("foo"))}, -1)
+	testJSONCompare(t, map[string]any{"key1": NewBlob([]byte("foo"))}, map[string]any{"key1": NewBlob([]byte("foo"))}, 0)
+	testJSONCompare(t, map[string]any{"key1": NewBlob([]byte("foo"))}, map[string]any{"key1": NewBlob([]byte("bar"))}, 1)
 }

--- a/pkg/json/decoder.go
+++ b/pkg/json/decoder.go
@@ -26,14 +26,14 @@ func IsJSON(bs []byte) bool {
 // standard package.
 type Decoder struct {
 	strings map[string]*String // for string interning.
-	keys    map[interface{}]*[]string
+	keys    map[any]*[]string
 	iter    *jsoniter.Iterator
 }
 
 func newDecoder(iter *jsoniter.Iterator) *Decoder {
 	return &Decoder{
 		strings: make(map[string]*String),
-		keys:    make(map[interface{}]*[]string),
+		keys:    make(map[any]*[]string),
 		iter:    iter,
 	}
 }

--- a/pkg/json/delta.go
+++ b/pkg/json/delta.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"sort"
 
-	"github.com/open-policy-agent/eopa/pkg/json/internal/utils"
+	"github.com/open-policy-agent/eopa/pkg/json/utils"
 )
 
 const (
@@ -236,6 +236,10 @@ func (d *deltaObjectReader) ObjectValueOffset(name string) (int64, bool, error) 
 
 func (d *deltaObjectReader) objectNameValueOffsets() ([]objectEntry, []int64, error) {
 	return d.impl.objectNameValueOffsets()
+}
+
+func (d *deltaObjectReader) objectValueOffset(i int) (int64, error) {
+	return d.impl.objectValueOffset(i)
 }
 
 func (d *deltaObjectReader) objectNameOffsetsValueOffsets() ([]objectEntry, []int64, []int64, error) {
@@ -818,7 +822,7 @@ func diffImpl(a contentReader, aoff int64, alen int64, b contentReader, boff int
 			value int64
 		}
 
-		namesValues := make(map[string]offsets)
+		namesValues := make(map[string]offsets, max(len(alla), len(allb)))
 
 		for i, entry := range alla {
 			name := entry.name
@@ -1019,7 +1023,7 @@ func reserialize(src contentReader, alen int64, off int64, embeddingAllowed bool
 		offsets := buffer.Len()
 		buffer.Write(make([]byte, 4*l))
 
-		for i := 0; i < l; i++ {
+		for i := range l {
 			voff, err := a.ArrayValueOffset(i)
 			if err != nil {
 				return 0, err

--- a/pkg/json/delta_test.go
+++ b/pkg/json/delta_test.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/open-policy-agent/eopa/pkg/json/internal/utils"
+	"github.com/open-policy-agent/eopa/pkg/json/utils"
 )
 
-func testDiff(t *testing.T, a interface{}, b interface{}) *deltaReader {
+func testDiff(t *testing.T, a any, b any) *deltaReader {
 	var x *snapshotReader
 	var y contentReader
 	var xn int64
@@ -859,12 +859,12 @@ func TestDeltaObject(t *testing.T) {
 func TestDeltaObjectTypes(t *testing.T) {
 	// An array with with two objects with the same names: 1) full definition, and 2) thinned one.
 
-	j, _ := buildJSON([]interface{}{
-		map[string]interface{}{
+	j, _ := buildJSON([]any{
+		map[string]any{
 			"a": "a",
 			"b": "b",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"a": "a",
 			"b": "b",
 		},
@@ -1025,7 +1025,7 @@ func TestDeltaEmbedding(t *testing.T) {
 }
 
 func getContent(t *testing.T, jsonStr string) (*snapshotReader, int64) {
-	var data interface{}
+	var data any
 	json.Unmarshal([]byte(jsonStr), &data)
 
 	c, n, err := translate(data)
@@ -1047,16 +1047,16 @@ func getBinaryContent(t *testing.T, data []byte) (*snapshotReader, int64) {
 
 // BenchmarkDeltaWrite benchmarks patching a large delta snapshot with a small patch.
 func BenchmarkDeltaWrite(b *testing.B) {
-	obj := make(map[string]interface{})
+	obj := make(map[string]any)
 
-	for i := 0; i < 10000; i++ {
+	for i := range 10000 {
 		obj[fmt.Sprintf("key:%d", i)] = fmt.Sprintf("value:%d", i)
 	}
 
 	now := time.Now()
 	snapshot := testCollectionCreate(testCollection{"": testResource{V: obj}}, now)
 
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		writable := snapshot.Writable()
 		doc := writable.Resource("").JSON().Clone(false).(Object)
 		doc.Set("key:1", NewString("patched"))

--- a/pkg/json/doc.go
+++ b/pkg/json/doc.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/open-policy-agent/eopa/pkg/json/internal/utils"
+	"github.com/open-policy-agent/eopa/pkg/json/utils"
 )
 
 type Kind uint
@@ -23,7 +23,7 @@ const (
 // metadata is to be accessed over the Resource interface (which represents a single entity in the namespace).
 type File interface {
 	io.WriterTo
-	Contents() interface{}
+	Contents() any
 
 	// Clone returns a (deep) copy of the file.
 	Clone(deepCopy bool) File
@@ -60,7 +60,7 @@ type Collections interface {
 
 	// Objects returns the storage objects below. 	If a snapshot based collection, the slice will hold only one entry, the snapshot object. If a
 	// delta based collection, the first entity will be the delta object and the second for the snapshot. Note the meta data may be nil, if it was not provided at the construction time.
-	Objects() []interface{}
+	Objects() []any
 
 	// Write operations. With binary collections they operate on the deltas.
 

--- a/pkg/json/hash.go
+++ b/pkg/json/hash.go
@@ -20,13 +20,13 @@ const (
 	typeHashSet
 )
 
-func hash(value interface{}) uint64 {
+func hash(value any) uint64 {
 	hasher := xxhash.New()
 	hashImpl(value, hasher)
 	return hasher.Sum64()
 }
 
-func hashImpl(value interface{}, hasher *xxhash.Digest) {
+func hashImpl(value any, hasher *xxhash.Digest) {
 	// Note Hasher writer below never returns an error.
 
 	switch value := value.(type) {
@@ -67,7 +67,7 @@ func hashImpl(value interface{}, hasher *xxhash.Digest) {
 
 	case Array:
 		n := value.Len()
-		for i := 0; i < n; i++ {
+		for i := range n {
 			hashImpl(value.Iterate(i), hasher)
 		}
 
@@ -85,7 +85,7 @@ func hashImpl(value interface{}, hasher *xxhash.Digest) {
 	case Object:
 		var m uint64
 		names := value.Names()
-		for i := 0; i < len(names); i++ {
+		for i := range names {
 			m = objectHashEntry(m, NewString(names[i]), value.Iterate(i))
 		}
 
@@ -108,7 +108,7 @@ func hashImpl(value interface{}, hasher *xxhash.Digest) {
 // objectHashEntry hashes an object key-value pair. To be used with
 // any object implementation, to guarantee identical hashing across
 // different object implementations.
-func objectHashEntry(h uint64, k, v interface{}) uint64 {
+func objectHashEntry(h uint64, k, v any) uint64 {
 	hasher := xxhash.New()
 	hashImpl(k, hasher)
 	hashImpl(v, hasher)

--- a/pkg/json/internal.go
+++ b/pkg/json/internal.go
@@ -78,6 +78,9 @@ type objectReader interface {
 
 	// objectNameOffsetsValueOffsets returns the property name and the offsets to key and value. The property has to exist.
 	objectNameOffsetsValueOffsets() ([]objectEntry, []int64, []int64, error)
+
+	// objectValueOffset returns the value offset at the given index.
+	objectValueOffset(i int) (int64, error)
 }
 
 // objectReader provides a convenient access to an array at offset. The rest of the content can be accessed through contentReader.
@@ -118,14 +121,14 @@ func newEncodingCache() *encodingCache {
 
 func (c *encodingCache) CacheObjectType(typeName []objectEntry, offset int32) int32 {
 	h := uint64(0)
-	for i := 0; i < len(typeName); i++ {
+	for i := range typeName {
 		h += xxhash.Sum64String(typeName[i].name)
 	}
 
 	objects, ok := c.objectTypes[h]
 	if ok {
 	next:
-		for i := 0; i < len(objects); i++ {
+		for i := range objects {
 			if len(typeName) != len(objects[i].properties) {
 				continue
 			}
@@ -154,7 +157,7 @@ func (c *encodingCache) CacheString(str string, offset int32) int32 {
 
 	strings, ok := c.strings[h]
 	if ok {
-		for i := 0; i < len(strings); i++ {
+		for i := range strings {
 			if strings[i].s == str {
 				return strings[i].offset
 			}

--- a/pkg/json/internal/json/decode.go
+++ b/pkg/json/internal/json/decode.go
@@ -542,10 +542,7 @@ func (d *decodeState) array(v reflect.Value) error {
 		if v.Kind() == reflect.Slice {
 			// Grow slice if necessary
 			if i >= v.Cap() {
-				newcap := v.Cap() + v.Cap()/2
-				if newcap < 4 {
-					newcap = 4
-				}
+				newcap := max(v.Cap()+v.Cap()/2, 4)
 				newv := reflect.MakeSlice(v.Type(), v.Len(), newcap)
 				reflect.Copy(newv, v)
 				v.Set(newv)

--- a/pkg/json/internal/json/encode.go
+++ b/pkg/json/internal/json/encode.go
@@ -908,7 +908,7 @@ type arrayEncoder struct {
 func (ae arrayEncoder) encode(e *encodeState, v reflect.Value, opts encOpts) {
 	e.WriteByte('[')
 	n := v.Len()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if i > 0 {
 			e.WriteByte(',')
 		}

--- a/pkg/json/internal/json/indent.go
+++ b/pkg/json/internal/json/indent.go
@@ -62,7 +62,7 @@ func compact(dst *bytes.Buffer, src []byte, escape bool) error {
 func newline(dst *bytes.Buffer, prefix, indent string, depth int) {
 	dst.WriteByte('\n')
 	dst.WriteString(prefix)
-	for i := 0; i < depth; i++ {
+	for range depth {
 		dst.WriteString(indent)
 	}
 }

--- a/pkg/json/json_test.go
+++ b/pkg/json/json_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
-	"github.com/open-policy-agent/eopa/pkg/json/internal/utils"
+	"github.com/open-policy-agent/eopa/pkg/json/utils"
 )
 
 func TestNil(t *testing.T) {
@@ -117,7 +117,7 @@ func TestFloat(t *testing.T) {
 func TestArray(t *testing.T) {
 	// Empty array
 
-	a := []interface{}{}
+	a := []any{}
 
 	j, err := buildJSON(a)
 	if err != nil {
@@ -137,7 +137,7 @@ func TestArray(t *testing.T) {
 
 	// Trivial array
 
-	a = []interface{}{"a"}
+	a = []any{"a"}
 
 	j, err = buildJSON(a)
 	if err != nil {
@@ -162,7 +162,7 @@ func TestArray(t *testing.T) {
 
 	// Longer array.
 
-	a = []interface{}{"a", "b", "c"}
+	a = []any{"a", "b", "c"}
 	j, err = buildJSON(a)
 	if err != nil {
 		t.Fatalf("Construction error: %v", err)
@@ -216,7 +216,7 @@ func TestArray(t *testing.T) {
 func TestObjectFull(t *testing.T) {
 	// Empty object
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 
 	j, err := buildJSON(m)
 	if err != nil {
@@ -227,7 +227,7 @@ func TestObjectFull(t *testing.T) {
 
 	// Trivial object
 
-	m = make(map[string]interface{})
+	m = make(map[string]any)
 	m["a"] = "b"
 
 	j, err = buildJSON(m)
@@ -302,15 +302,15 @@ func TestObjectFull(t *testing.T) {
 func TestObjectThin(t *testing.T) {
 	// An array with with two objects with the same names.
 
-	mx := make(map[string]interface{})
+	mx := make(map[string]any)
 	mx["a"] = "xa"
 	mx["b"] = "xb"
 
-	my := make(map[string]interface{})
+	my := make(map[string]any)
 	my["a"] = "ya"
 	my["b"] = "yb"
 
-	a := []interface{}{mx, my}
+	a := []any{mx, my}
 
 	j, err := buildJSON(a)
 	if err != nil {
@@ -386,10 +386,10 @@ func TestObjectThin(t *testing.T) {
 
 	// An array with with two empty objects (the latter will be thin).
 
-	mx = make(map[string]interface{})
-	my = make(map[string]interface{})
+	mx = make(map[string]any)
+	my = make(map[string]any)
 
-	a = []interface{}{mx, my}
+	a = []any{mx, my}
 
 	j, err = buildJSON(a)
 	if err != nil {
@@ -440,7 +440,7 @@ func TestObjectThin(t *testing.T) {
 func TestDeduplication(t *testing.T) {
 	// Test the strings and floats are dedup'ed.
 
-	a := []interface{}{"a", "a", float64(0.1234), float64(0.1234)}
+	a := []any{"a", "a", float64(0.1234), float64(0.1234)}
 	j, err := buildJSON(a)
 	if err != nil {
 		t.Fatalf("Construction error: %v", err)
@@ -492,7 +492,7 @@ func TestDeduplication(t *testing.T) {
 func TestEmbeddingArray(t *testing.T) {
 	// Test nils and booleans are properly embedded into offsets within arrays.
 
-	a := []interface{}{nil, false, true}
+	a := []any{nil, false, true}
 	j, err := buildJSON(a)
 	if err != nil {
 		t.Fatalf("Construction error: %v", err)
@@ -534,13 +534,13 @@ func TestEmbeddingArray(t *testing.T) {
 func TestEmbeddingObject(t *testing.T) {
 	// Test nils and booleans are properly embedded into offsets within objects.
 
-	a := []interface{}{
-		map[string]interface{}{
+	a := []any{
+		map[string]any{
 			"a": nil,
 			"b": false,
 			"c": true,
 		},
-		map[string]interface{}{
+		map[string]any{
 			"a": nil,
 			"b": false,
 			"c": true,
@@ -648,10 +648,10 @@ func TestEmbeddingObject(t *testing.T) {
 
 func TestNewWriteTo(t *testing.T) {
 	str := "string"
-	var empty interface{}
-	var i interface{} = str
+	var empty any
+	var i any = str
 	//var bigint *big.Int
-	for n, test := range []interface{}{
+	for n, test := range []any{
 		// Golang JSON native types
 		testBuildJSON(`null`),
 		testBuildJSON(`1234`),
@@ -677,10 +677,10 @@ func TestNewWriteTo(t *testing.T) {
 		[]string{},
 		[]string{"foo", "bar"},
 		[2]string{"foo", "bar"},
-		[]interface{}(nil),
-		[]interface{}{},
-		[]interface{}{"foo", "bar"},
-		[2]interface{}{"foo", "bar"},
+		[]any(nil),
+		[]any{},
+		[]any{"foo", "bar"},
+		[2]any{"foo", "bar"},
 		int(1),
 		int16(16),
 		int32(32),
@@ -694,26 +694,26 @@ func TestNewWriteTo(t *testing.T) {
 		map[string]string(nil),
 		map[string]string{},
 		map[string]string{"foo": "bar"},
-		map[string]interface{}(nil),
-		map[string]interface{}{},
-		map[string]interface{}{"foo": "bar"},
+		map[string]any(nil),
+		map[string]any{},
+		map[string]any{"foo": "bar"},
 		time.Now(), // time.Time has MarshalJSON interface.
 		(*textMarshaler)(nil),
 		textMarshaler{},
 		textMarshaler2{},
 		&textMarshaler2{},
 		struct {
-			A1    []interface{}
-			A2    []interface{}
-			A3    []interface{}
+			A1    []any
+			A2    []any
+			A3    []any
 			A4    [2]string
 			B1    bool `json:"Bool1"`
 			B2    bool `json:"Bool2,omitempty"`
 			F1    float32
 			F2    float64
-			I1    interface{}
-			I2    interface{}
-			I3    *interface{}
+			I1    any
+			I2    any
+			I3    *any
 			Int   int
 			Int16 int16
 			Int32 int32
@@ -740,8 +740,8 @@ func TestNewWriteTo(t *testing.T) {
 			UInt8  uint8
 		}{
 			// A1 has null value
-			A2: []interface{}{},
-			A3: []interface{}{"bar", "foo"},
+			A2: []any{},
+			A3: []any{"bar", "foo"},
 			A4: [2]string{"foo", "bar"},
 			B1: true,
 			B2: false,
@@ -880,7 +880,7 @@ func TestObject(t *testing.T) {
 	}
 }
 
-func buildJSON(data interface{}) (Json, error) {
+func buildJSON(data any) (Json, error) {
 	cache := newEncodingCache()
 	buffer := new(bytes.Buffer)
 
@@ -908,7 +908,7 @@ func validateSerialization(t *testing.T, j File, valid []byte) {
 func TestAST(t *testing.T) {
 	tests := []struct {
 		note  string
-		value interface{}
+		value any
 	}{
 		{
 			value: nil,
@@ -923,15 +923,15 @@ func TestAST(t *testing.T) {
 			value: "string",
 		},
 		{
-			value: []interface{}{"a", "b"},
+			value: []any{"a", "b"},
 		},
 		{
-			value: map[string]interface{}{"a": "b"},
+			value: map[string]any{"a": "b"},
 		},
 		{
-			value: map[string]interface{}{
-				"a": []interface{}{
-					map[string]interface{}{
+			value: map[string]any{
+				"a": []any{
+					map[string]any{
 						"foo": "bar",
 					},
 				},

--- a/pkg/json/object.go
+++ b/pkg/json/object.go
@@ -34,9 +34,9 @@ func (objectMapBase[T]) Value(o T, name string) Json {
 	return nil
 }
 
-func (objectMapBase[T]) JSON(o T) interface{} {
+func (objectMapBase[T]) JSON(o T) any {
 	keys := o.Names()
-	object := make(map[string]interface{}, len(keys))
+	object := make(map[string]any, len(keys))
 	for i := range keys {
 		j, ok := o.iterate(i).(Json)
 		if ok {
@@ -205,8 +205,8 @@ func (objectMapBase[T]) Union(o T, other Json) Json {
 }
 
 func (objectMapBase[T]) clone(o T, internedKeys *[]string, deepCopy bool) *ObjectMap {
-	values := make([]interface{}, len(*internedKeys))
-	for i := 0; i < len(values); i++ {
+	values := make([]any, len(*internedKeys))
+	for i := range values {
 		v := o.iterate(i)
 		if deepCopy {
 			v = v.Clone(true)
@@ -218,7 +218,7 @@ func (objectMapBase[T]) clone(o T, internedKeys *[]string, deepCopy bool) *Objec
 	return &ObjectMap{internedKeys, values}
 }
 
-func (objectMapBase[T]) intern(s []string, keys map[interface{}]*[]string) *[]string {
+func (objectMapBase[T]) intern(s []string, keys map[any]*[]string) *[]string {
 	if keys == nil {
 		return &s
 	}
@@ -243,7 +243,7 @@ type ObjectMapCompact[T indexable] struct {
 	values       T
 }
 
-func NewObjectMapCompact(properties map[string]File, interning map[interface{}]*[]string) Object {
+func NewObjectMapCompact(properties map[string]File, interning map[any]*[]string) Object {
 	if o := NewObjectMapCompactStrings(properties, interning); o != nil {
 		return o
 	}
@@ -356,7 +356,7 @@ type indexable interface {
 		~[32]File
 }
 
-func newObjectMapCompact[T indexable](properties map[string]File, interning map[interface{}]*[]string) Object {
+func newObjectMapCompact[T indexable](properties map[string]File, interning map[any]*[]string) Object {
 	var obj ObjectMapCompact[T]
 
 	i := 0
@@ -395,7 +395,7 @@ func (o *ObjectMapCompact[T]) WriteTo(w io.Writer) (int64, error) {
 	return objectMapBase[*ObjectMapCompact[T]]{}.WriteTo(o, w)
 }
 
-func (o *ObjectMapCompact[T]) Contents() interface{} {
+func (o *ObjectMapCompact[T]) Contents() any {
 	return o.JSON()
 }
 
@@ -465,7 +465,7 @@ func (o *ObjectMapCompact[T]) Len() int {
 	return len(o.values)
 }
 
-func (o *ObjectMapCompact[T]) JSON() interface{} {
+func (o *ObjectMapCompact[T]) JSON() any {
 	return objectMapBase[*ObjectMapCompact[T]]{}.JSON(o)
 }
 
@@ -505,7 +505,7 @@ func (o *ObjectMapCompact[T]) Union(other Json) Json {
 	return objectMapBase[*ObjectMapCompact[T]]{}.Union(o, other)
 }
 
-func (o *ObjectMapCompact[T]) intern(s []string, keys map[interface{}]*[]string) *[]string {
+func (o *ObjectMapCompact[T]) intern(s []string, keys map[any]*[]string) *[]string {
 	return objectMapBase[*ObjectMapCompact[T]]{}.intern(s, keys)
 }
 

--- a/pkg/json/object2.go
+++ b/pkg/json/object2.go
@@ -15,7 +15,7 @@ var (
 	zeroObject2 Object2 = &objectCompact[[0]hashObjectCompactEntry]{}
 )
 
-type T = interface{}
+type T = any
 
 type Object2 interface {
 	Json
@@ -27,7 +27,7 @@ type Object2 interface {
 	get(hash uint64, k Json) (Json, bool)
 	Iter(iter func(key, value Json) (bool, error)) error
 	iter(iter func(hash uint64, key, value Json))
-	Iter2(iter func(key, value interface{}) (bool, error)) error
+	Iter2(iter func(key, value any) (bool, error)) error
 	Equal(other Object2) bool
 	Diff(other Object2) Object2
 	Len() int
@@ -152,7 +152,7 @@ func (o *objectLarge) iter(iter func(hash uint64, key, value Json)) {
 	}
 }
 
-func (o *objectLarge) Iter2(iter func(key, value interface{}) (bool, error)) error {
+func (o *objectLarge) Iter2(iter func(key, value any) (bool, error)) error {
 	for _, entry := range o.table {
 		for ; entry != nil; entry = entry.next {
 			if stop, err := iter(entry.k, entry.v); err != nil {
@@ -248,7 +248,7 @@ func (o *objectLarge) Union(other Object2) Object2 {
 	return result
 }
 
-func (o *objectLarge) hash(k interface{}) uint64 {
+func (o *objectLarge) hash(k any) uint64 {
 	return hash(k)
 }
 
@@ -388,7 +388,7 @@ func (o *objectCompact[T]) iter(iter func(hash uint64, key, value Json)) {
 	}
 }
 
-func (o *objectCompact[T]) Iter2(iter func(key, value interface{}) (bool, error)) error {
+func (o *objectCompact[T]) Iter2(iter func(key, value any) (bool, error)) error {
 	var (
 		stop bool
 		err  error
@@ -477,7 +477,7 @@ func (o *objectCompact[T]) Union(other Object2) Object2 {
 	return result
 }
 
-func (o *objectCompact[T]) hash(k interface{}) uint64 {
+func (o *objectCompact[T]) hash(k any) uint64 {
 	return hash(k)
 }
 

--- a/pkg/json/object2_test.go
+++ b/pkg/json/object2_test.go
@@ -12,7 +12,7 @@ import (
 func TestObject2(t *testing.T) {
 	obj := zeroObject2
 
-	for i := 0; i < 32; i++ {
+	for i := range 32 {
 		t.Run("", func(t *testing.T) {
 			expected := make(map[string]string)
 			for j := 0; j < i; j++ {

--- a/pkg/json/object_strings.go
+++ b/pkg/json/object_strings.go
@@ -53,7 +53,7 @@ type indexableStrings interface {
 		[32]*String
 }
 
-func NewObjectMapCompactStrings(properties map[string]File, interning map[interface{}]*[]string) Object {
+func NewObjectMapCompactStrings(properties map[string]File, interning map[any]*[]string) Object {
 	n := len(properties)
 	if n == 0 || n > 32 {
 		return nil
@@ -137,7 +137,7 @@ func NewObjectMapCompactStrings(properties map[string]File, interning map[interf
 	panic("not reached")
 }
 
-func newObjectMapCompactStrings[T indexableStrings](properties map[string]File, interning map[interface{}]*[]string) Object {
+func newObjectMapCompactStrings[T indexableStrings](properties map[string]File, interning map[any]*[]string) Object {
 	var obj ObjectMapCompactStrings[T]
 
 	i := 0
@@ -176,7 +176,7 @@ func (o *ObjectMapCompactStrings[T]) WriteTo(w io.Writer) (int64, error) {
 	return objectMapBase[*ObjectMapCompactStrings[T]]{}.WriteTo(o, w)
 }
 
-func (o *ObjectMapCompactStrings[T]) Contents() interface{} {
+func (o *ObjectMapCompactStrings[T]) Contents() any {
 	return o.JSON()
 }
 
@@ -252,7 +252,7 @@ func (o *ObjectMapCompactStrings[T]) Len() int {
 	return len(o.values)
 }
 
-func (o *ObjectMapCompactStrings[T]) JSON() interface{} {
+func (o *ObjectMapCompactStrings[T]) JSON() any {
 	return objectMapBase[*ObjectMapCompactStrings[T]]{}.JSON(o)
 }
 
@@ -292,7 +292,7 @@ func (o *ObjectMapCompactStrings[T]) Union(other Json) Json {
 	return objectMapBase[*ObjectMapCompactStrings[T]]{}.Union(o, other)
 }
 
-func (o *ObjectMapCompactStrings[T]) intern(s []string, keys map[interface{}]*[]string) *[]string {
+func (o *ObjectMapCompactStrings[T]) intern(s []string, keys map[any]*[]string) *[]string {
 	return objectMapBase[*ObjectMapCompactStrings[T]]{}.intern(s, keys)
 }
 

--- a/pkg/json/object_strings_test.go
+++ b/pkg/json/object_strings_test.go
@@ -59,7 +59,7 @@ func TestObjectStringsSizes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			var native interface{}
+			var native any
 			if err := util.NewJSONDecoder(bytes.NewBufferString(test.json)).Decode(&native); err != nil {
 				t.Fatal(err)
 			}
@@ -75,7 +75,7 @@ func TestObjectStringsSizes(t *testing.T) {
 				t.Errorf("incorrect json marshaling: %s", doc.String())
 			}
 
-			var nativeObj = native.(map[string]interface{})
+			var nativeObj = native.(map[string]any)
 			var obj = doc.(Object)
 
 			obj = obj.Clone(true).(Object)

--- a/pkg/json/object_test.go
+++ b/pkg/json/object_test.go
@@ -59,7 +59,7 @@ func TestObjectSizes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			var native interface{}
+			var native any
 			if err := util.NewJSONDecoder(bytes.NewBufferString(test.json)).Decode(&native); err != nil {
 				t.Fatal(err)
 			}
@@ -75,7 +75,7 @@ func TestObjectSizes(t *testing.T) {
 				t.Errorf("incorrect json marshaling: %s", doc.String())
 			}
 
-			var nativeObj = native.(map[string]interface{})
+			var nativeObj = native.(map[string]any)
 			var obj = doc.(Object)
 
 			obj = obj.Clone(true).(Object)

--- a/pkg/json/patch.go
+++ b/pkg/json/patch.go
@@ -31,7 +31,7 @@ type Op struct {
 	From        string  `json:"from"` // Note, only marshaled if operation is either copy or move.
 }
 
-type JsonPatchSpec []map[string]interface{}
+type JsonPatchSpec []map[string]any
 
 func NewPatch(spec JsonPatchSpec) (Patch, error) {
 	patch := make(Patch, 0, len(spec))
@@ -45,7 +45,7 @@ func NewPatch(spec JsonPatchSpec) (Patch, error) {
 	return patch, nil
 }
 
-func newOpFromMap(spec map[string]interface{}) (Op, error) {
+func newOpFromMap(spec map[string]any) (Op, error) {
 	op, ok := spec["op"]
 	if !ok {
 		return Op{}, errors.New("json patch: op is missing")
@@ -106,7 +106,7 @@ func (p *Patch) UnmarshalJSON(data []byte) error {
 func (p *Patch) Unmarshal(decoder *Decoder) error {
 	*p = make([]Op, 0)
 	return decoder.UnmarshalArray(func(decoder *Decoder) error {
-		opData := map[string]interface{}{}
+		opData := map[string]any{}
 
 		if err := decoder.UnmarshalObject(func(property string, decoder *Decoder) error {
 			var err error
@@ -126,7 +126,7 @@ func (p *Patch) Unmarshal(decoder *Decoder) error {
 				}
 
 			case "value":
-				var value interface{}
+				var value any
 				value, err = decoder.Decode()
 				if err == nil {
 					opData["value"] = value

--- a/pkg/json/patch_test.go
+++ b/pkg/json/patch_test.go
@@ -523,9 +523,9 @@ func TestPatch(t *testing.T) {
 
 	var tests []struct {
 		Comment  string        `json:"comment"`
-		Doc      interface{}   `json:"doc"`
+		Doc      any           `json:"doc"`
 		Patch    JsonPatchSpec `json:"patch"`
-		Expected interface{}   `json:"expected"`
+		Expected any           `json:"expected"`
 		Error    string        `json:"error"`
 		Disabled bool          `json:"disabled"`
 	}
@@ -590,7 +590,7 @@ func TestPatch(t *testing.T) {
 				t.Fatalf("marshaling/unmarshaling round trip didn't result to equal result")
 			}
 
-			for i := 0; i < len(patch); i++ {
+			for i := range patch {
 				if patch[i].Op != patch2[i].Op ||
 					patch[i].Path != patch2[i].Path ||
 					!((patch[i].Value == nil && patch2[i].Value == nil) || patch[i].Value.Compare(patch2[i].Value) == 0) || // nolint:staticcheck

--- a/pkg/json/ptr.go
+++ b/pkg/json/ptr.go
@@ -76,7 +76,7 @@ func EscapePointerSeg(ptr string) string {
 // The function returns an error if no element found (to separate from
 // the case value being a nil). That is, it is up to the caller to
 // determine the exact semantics of no element found.
-func Extract(json interface{}, ptr string) (interface{}, error) {
+func Extract(json any, ptr string) (any, error) {
 	if doc, ok := json.(Json); ok {
 		return doc.Extract(ptr)
 	}

--- a/pkg/json/ptr_test.go
+++ b/pkg/json/ptr_test.go
@@ -48,18 +48,18 @@ func TestJSONPointer(t *testing.T) {
 	s := t1{"x", &i, t2{"z"}, t2{"w"}, t3{"q"}}
 	str := "v"
 	pstr := &str
-	var iface, iface2 interface{}
+	var iface, iface2 any
 	iface = str
 	iface2 = &str
 
 	tests := []struct {
-		doc      interface{}
+		doc      any
 		pointer  string
-		expected interface{}
+		expected any
 	}{
 		// Test document and paths from RFC 6901.
 		{rfc6901, "", rfc6901},
-		{rfc6901, "/foo", []interface{}{"bar", "baz"}},
+		{rfc6901, "/foo", []any{"bar", "baz"}},
 		{rfc6901, "/foo/0", "bar"},
 		{rfc6901, "/", float64(0)},
 		{rfc6901, "/a~1b", float64(1)},
@@ -82,11 +82,11 @@ func TestJSONPointer(t *testing.T) {
 		// Exercise both map field access and more complicated primitive values.
 		{map[int]string{1: "v"}, "/1", "v"},
 		{map[int]*string{1: &str}, "/1", "v"},
-		{map[int]interface{}{1: &str}, "/1", "v"},
-		{map[int]interface{}{1: iface}, "/1", "v"},
-		{map[int]interface{}{1: iface2}, "/1", "v"},
-		{map[int]interface{}{1: &iface}, "/1", "v"},
-		{map[int]interface{}{1: &iface2}, "/1", "v"},
+		{map[int]any{1: &str}, "/1", "v"},
+		{map[int]any{1: iface}, "/1", "v"},
+		{map[int]any{1: iface2}, "/1", "v"},
+		{map[int]any{1: &iface}, "/1", "v"},
+		{map[int]any{1: &iface2}, "/1", "v"},
 		{map[int8]string{1: "v"}, "/1", "v"},
 		{map[int16]string{1: "v"}, "/1", "v"},
 		{map[int32]string{1: "v"}, "/1", "v"},
@@ -150,9 +150,9 @@ func TestJSONPointerNotFound(t *testing.T) {
 	v := testBuildJSON(`{"foo": ["bar", "baz"], "a": true, "b": null, "c": 0}`)
 
 	tests := []struct {
-		doc      interface{}
+		doc      any
 		pointer  string
-		expected interface{}
+		expected any
 	}{
 		{v, "/bar", nil},
 		{v, "/foo/2", nil},
@@ -202,8 +202,8 @@ func TestJSONPointerNotFound(t *testing.T) {
 	}
 }
 
-func testBuildJSON(s string) interface{} {
-	var v interface{}
+func testBuildJSON(s string) any {
+	var v any
 	if err := json.Unmarshal([]byte(s), &v); err != nil {
 		panic("Invalid JSON snippet")
 	}

--- a/pkg/json/set.go
+++ b/pkg/json/set.go
@@ -23,7 +23,7 @@ type Set interface {
 	add(hash uint64, v Json) Set
 	Get(v Json) (Json, bool)
 	Iter(iter func(v Json) (bool, error)) (bool, error)
-	Iter2(iter func(v, vv interface{}) (bool, error)) (bool, error)
+	Iter2(iter func(v, vv any) (bool, error)) (bool, error)
 	Equal(other Set) bool
 	Len() int
 	Hash() uint64
@@ -125,7 +125,7 @@ func (o *setLarge) Iter(iter func(v Json) (bool, error)) (bool, error) {
 
 	return false, nil
 }
-func (o *setLarge) Iter2(iter func(v, vv interface{}) (bool, error)) (bool, error) {
+func (o *setLarge) Iter2(iter func(v, vv any) (bool, error)) (bool, error) {
 	for _, entry := range o.table {
 		for ; entry != nil; entry = entry.next {
 			if stop, err := iter(entry.v, entry.v); err != nil {
@@ -193,7 +193,7 @@ func (o *setLarge) AST() ast.Value {
 	return ast.NewSet(terms...)
 }
 
-func (o *setLarge) hash(k interface{}) uint64 {
+func (o *setLarge) hash(k any) uint64 {
 	return hash(k)
 }
 
@@ -284,7 +284,7 @@ func (o *setCompact[T]) Iter(iter func(v Json) (bool, error)) (bool, error) {
 	return stop, err
 }
 
-func (o *setCompact[T]) Iter2(iter func(v, vv interface{}) (bool, error)) (bool, error) {
+func (o *setCompact[T]) Iter2(iter func(v, vv any) (bool, error)) (bool, error) {
 	var (
 		stop bool
 		err  error
@@ -345,7 +345,7 @@ func (o *setCompact[T]) AST() ast.Value {
 	return ast.NewSet(terms...)
 }
 
-func (o *setCompact[T]) hash(k interface{}) uint64 {
+func (o *setCompact[T]) hash(k any) uint64 {
 	return hash(k)
 }
 

--- a/pkg/json/set_test.go
+++ b/pkg/json/set_test.go
@@ -14,7 +14,7 @@ import (
 func TestSet(t *testing.T) {
 	set := zeroSet
 
-	for i := 0; i < 32; i++ {
+	for i := range 32 {
 		t.Run("", func(t *testing.T) {
 			expected := make(map[string]struct{})
 			for j := 0; j < i; j++ {
@@ -42,7 +42,7 @@ func TestSet(t *testing.T) {
 
 			// Iter2
 			contents = make(map[string]struct{})
-			set.Iter2(func(v, vv interface{}) (bool, error) {
+			set.Iter2(func(v, vv any) (bool, error) {
 				if v.(*String).Value() != vv.(*String).Value() {
 					t.Fatal("unexpected iteration")
 				}
@@ -50,7 +50,7 @@ func TestSet(t *testing.T) {
 				return false, nil
 			})
 			c = 0
-			set.Iter2(func(_, _ interface{}) (bool, error) {
+			set.Iter2(func(_, _ any) (bool, error) {
 				c++
 				return true, nil
 			})

--- a/pkg/json/snapshot_test.go
+++ b/pkg/json/snapshot_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/open-policy-agent/eopa/pkg/json/internal/utils"
+	"github.com/open-policy-agent/eopa/pkg/json/utils"
 )
 
 func TestCollectionsSerialization(t *testing.T) {
@@ -24,7 +24,7 @@ func testCollectionsSerialization(t *testing.T, jsonStr string) {
 	collections := NewCollections()
 
 	if jsonStr != "" {
-		var data interface{}
+		var data any
 		gojson.Unmarshal([]byte(jsonStr), &data)
 
 		c, err := New(data)
@@ -97,9 +97,9 @@ func TestCollectionsDeltaSerialization(t *testing.T) {
 func TestCollectionsNamespace(t *testing.T) {
 	// Populate a writable collection with three collections.
 
-	data1 := map[string]interface{}{"foo": "foo"}
-	data2 := map[string]interface{}{"foo": "bar"}
-	data3 := map[string]interface{}{"foo": "foobar"}
+	data1 := map[string]any{"foo": "foo"}
+	data2 := map[string]any{"foo": "bar"}
+	data3 := map[string]any{"foo": "foobar"}
 
 	wcollections := NewCollections()
 	coll1, err := New(data1)

--- a/pkg/json/unmarshal.go
+++ b/pkg/json/unmarshal.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Unmarshal stores the JSON data in the value pointed to by v.
-func Unmarshal(data Json, v interface{}) error {
+func Unmarshal(data Json, v any) error {
 	var buf bytes.Buffer
 	if _, err := data.WriteTo(&buf); err != nil {
 		return err
@@ -20,7 +20,7 @@ func Unmarshal(data Json, v interface{}) error {
 }
 
 // UnmarshalUseNumber stores the JSON data in the value pointed to by v. Numbers are stored as json.Number
-func UnmarshalUseNumber(data Json, v interface{}) error {
+func UnmarshalUseNumber(data Json, v any) error {
 	var buf bytes.Buffer
 	if _, err := data.WriteTo(&buf); err != nil {
 		return err

--- a/pkg/json/unmarshal_test.go
+++ b/pkg/json/unmarshal_test.go
@@ -31,7 +31,7 @@ func TestUnmarshalObject(t *testing.T) {
 		t.Errorf("parsing failure: %s", err)
 	}
 
-	correct, _ := New(map[string]interface{}{"a": "x", "b": "y"})
+	correct, _ := New(map[string]any{"a": "x", "b": "y"})
 	if correct.Compare(parsed) != 0 {
 		t.Error("parsing failure: not equal")
 	}
@@ -51,7 +51,7 @@ func TestUnmarshalArray(t *testing.T) {
 		t.Errorf("parsing failure: %s", err)
 	}
 
-	correct, _ := New([]interface{}{"a", "b"})
+	correct, _ := New([]any{"a", "b"})
 	if correct.Compare(parsed) != 0 {
 		t.Error("parsing failure: not equal")
 	}

--- a/pkg/json/utils/str.go
+++ b/pkg/json/utils/str.go
@@ -3,12 +3,10 @@
 
 package utils
 
+import "slices"
+
+// Deprecated: Use slices.Contains instead.
 // Contains returns true if input contains the given string.
 func Contains(input []string, s string) bool {
-	for _, k := range input {
-		if k == s {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(input, s)
 }


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

This PR is a combination of a modernization pass (using the CLI version of the `modernize` linter) + many small performance improvements and convenience feature additions around the `ObjectBinary` and delta patching features.

Huge thanks to @koponen for the heavy lifting on the BJSON performance tweaks.

Notable changes include:
 - `NewObjectBinary` function. (Makes creating binary objects *much* simpler.)
 - BJSON object insert logic change (`setImpl` change to avoid extra copying.)
 - BJSON storage layer recursively searches parents on failed Read call, in case the parent is an `ObjectBinary` snapshot.
 - Teemu's tweaks for object offset computation.
 - Snapshot + Delta updating with the `PatchObjectBinary` function. (Makes applying patches against an existing snapshot (+ delta) easier.)

### :+1: Definition of done

 - [x] Migrate `pkg/json/internal/utils/io.go` into a public package. (Makes the `utils.BytesReader` and `utils.MultiReader` types available for library users.)
 - Do all of our tests in CI still pass? 😅 

### :athletic_shoe: How to test

### :chains: Related Resources
